### PR TITLE
Поменял логику работы pseudo-levels builder

### DIFF
--- a/lib/plugins/pseudo-levels/builder.js
+++ b/lib/plugins/pseudo-levels/builder.js
@@ -30,11 +30,12 @@ var path = require('path'),
  *
  * <set-name>.examples
  *  └── <block-name>/
- *       ├── .blocks/             # уровень для всех примеров блока <block-name>
  *       ├── 10-simple/
- *           ├── blocks/          # уровень для примера 10-simple
+ *           ├── <block-name>.blocks/    # уровень для всех примеров блока <block-name>
+ *           ├── 10-simple.blocks/       # уровень для примера 10-simple
  *           └── 10-simple.bemjson.js.symlink
  *       └── 20-complex/
+ *           ├── <block-name>.blocks/    # уровень для всех примеров блока <block-name>
  *           └── 20-comples.bemjson.js.symlink
  *
  * @param {Object} options
@@ -44,39 +45,59 @@ var path = require('path'),
  */
 module.exports = function (options) {
     return function (dir) {
-        if (dir.isDirectory && options.techSuffixes.indexOf(dir.suffix) !== -1) {
-            var scope = dir.name.split('.')[0],
-                files = dir.files,
-                res = [];
+        if (!dir.isDirectory || options.techSuffixes.indexOf(dir.suffix) === -1) {
+            return;
+        }
 
-            files && files.length && files.forEach(function (file) {
-                var basename = file.name,
-                    bemname = basename.split('.')[0],
-                    suffix = file.suffix,
-                    hasSublevel = false;
+        var files = [],
+            commonSublevel; // Уровень для всех примеров
 
-                // Уровень для всех примеров
-                if (basename === SUBLEVEL_NAME) {
-                    basename = '.blocks';
-                    bemname = '';
-                    hasSublevel = true;
-                } else
-                // Уровень только для текущего примера
-                if (suffix === SUBLEVEL_NAME) {
-                    basename = 'blocks';
-                    hasSublevel = true;
-                }
+        (dir.files || []).forEach(function (file) {
+            if (file.name === SUBLEVEL_NAME) {
+                commonSublevel = file;
+                return;
+            }
 
-                if (hasSublevel || options.fileSuffixes.indexOf(suffix) !== -1) {
-                    res.push({
-                        targetPath: path.join(scope, bemname, file.isDirectory ? basename : basename + SYMLINK_EXT),
-                        sourcePath: file.fullname,
-                        isDirectory: file.isDirectory
-                    });
-                }
+            files.push(file);
+        });
+
+        var scope = getPrefix(dir.name),
+            res = [];
+
+        files.forEach(function (file) {
+            var basename = file.name,
+                bemname = getPrefix(basename),
+                suffix = file.suffix,
+                shouldBeAdded = options.fileSuffixes.indexOf(suffix) !== -1;
+
+            if (suffix === SUBLEVEL_NAME) { // Уровень только для текущего примера
+                basename = bemname + '.blocks';
+                shouldBeAdded = true;
+            }
+
+            var examplePath = path.join(scope, bemname);
+
+            shouldBeAdded && res.push({
+                targetPath: path.join(examplePath, file.isDirectory ? basename : basename + SYMLINK_EXT),
+                sourcePath: file.fullname,
+                isDirectory: file.isDirectory
             });
 
-            return res;
-        }
+            shouldBeAdded && commonSublevel && res.push({
+                targetPath: path.join(examplePath, scope + '.blocks'),
+                sourcePath: commonSublevel.fullname,
+                isDirectory: true
+            });
+        });
+
+        return res;
     };
 };
+
+/**
+ * @param {String} filename
+ * @returns {String}
+ */
+function getPrefix(filename) {
+    return filename.split('.')[0];
+}


### PR DESCRIPTION
/cc @blond 

closes #15 #18 

##### Не подключается уровень `*.examples/blocks` если собирать пример точечно

```bash 
$ enb make examples desktop.examples/block/example # не подключается
$ enb make examples desktop.examples/block # подключается
```
Ожидается, что уровень `*.examples/blocks`будет подключаться для любого примера, вне зависимости от того как мы его собираем.

---------------------

##### Решение

Папка-симлинка с общими блоками примеров блока создается в каждом примере отдельно, то есть **было**:

```bash
 <set-name>.examples
  └── <block-name>/
       ├── .blocks/             # уровень для всех примеров блока <block-name>
       ├── 10-simple/
           ├── blocks/          # уровень для примера 10-simple
           └── 10-simple.bemjson.js.symlink
       └── 20-complex/
           └── 20-comples.bemjson.js.symlink
```

а **стало**:

```bash
 <set-name>.examples
  └── <block-name>/
       ├── 10-simple/
           ├── <block-name>.blocks/    # уровень для всех примеров блока <block-name>
           ├── 10-simple.blocks/       # уровень для примера 10-simple
           └── 10-simple.bemjson.js.symlink
       └── 20-complex/
           ├── <block-name>.blocks/    # уровень для всех примеров блока <block-name>
           └── 20-comples.bemjson.js.symlink
```

**Важно!** Мажорное изменение!